### PR TITLE
Move --json and --csv flags into an argument group

### DIFF
--- a/gen-tz.py
+++ b/gen-tz.py
@@ -493,8 +493,9 @@ def print_json(timezones_dict):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Generates POSIX timezones strings reading data from " + ZONES_DIR)
-    parser.add_argument("-j", "--json", action="store_true", help="outputs JSON")
-    parser.add_argument("-c", "--csv", action="store_true", help="outputs CSV")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("-j", "--json", action="store_true", help="outputs JSON")
+    group.add_argument("-c", "--csv", action="store_true", help="outputs CSV")
     data = parser.parse_args()
 
     timezones = make_timezones_dict()


### PR DESCRIPTION
Just a small quality-of-life improvement. No change in typical usage.

The current behavior of the generating script is that passing in both `-j` and `-c` will print JSON, and passing in neither will print CSV. With this change, it'll complain as follows:

With both:
```
usage: gen-tz.py [-h] (-j | -c)
gen-tz.py: error: argument -c/--csv: not allowed with argument -j/--json
```

With neither:
```
usage: gen-tz.py [-h] (-j | -c)
gen-tz.py: error: one of the arguments -j/--json -c/--csv is required
```

(This is mostly motivated by me wanting to add an array of C structs as an output in my fork, the conditional feels less natural with a third output) 